### PR TITLE
General improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4674,9 +4674,9 @@ mod tests {
                 .count(),
             5000
         );
-        assert!(PathBuf::from(tmp_dir.path().join("parquet/main.parquet")).exists());
-        assert!(PathBuf::from(tmp_dir.path().join("sqlite.db")).exists());
-        assert!(PathBuf::from(tmp_dir.path().join("output.xlsx")).exists());
+        assert!(tmp_dir.path().join("parquet/main.parquet").exists());
+        assert!(tmp_dir.path().join("sqlite.db").exists());
+        assert!(tmp_dir.path().join("output.xlsx").exists());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3022,7 +3022,7 @@ pub fn flatten_to_memory<R: Read>(input: BufReader<R>, mut options: Options) -> 
                 json = pointed.take();
             } else {
                 return Err(Error::FlattererProcessError {
-                    message: format!("No value at given path"),
+                    message: "No value at given path".to_string(),
                 });
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2246,7 +2246,7 @@ impl FlatFiles {
             );
 
             if !self.options.xlsx {
-                self.tmp_memory.remove(table_name);
+                self.tmp_memory.swap_remove(table_name);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@
 //!```
 
 #![allow(clippy::invalid_regex)]
+#![allow(clippy::large_enum_variant)]
+#![allow(clippy::result_large_err)]
 
 mod guess_array;
 mod postgresql;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@
 //!
 //!```
 
+#![allow(clippy::invalid_regex)]
+
 mod guess_array;
 mod postgresql;
 
@@ -147,7 +149,6 @@ lazy_static::lazy_static! {
 }
 
 lazy_static::lazy_static! {
-    #[allow(clippy::invalid_regex)]
     static ref INVALID_REGEX: regex::Regex = regex::RegexBuilder::new(r"[\000-\010]|[\013-\014]|[\016-\037]")
         .octal(true)
         .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3387,10 +3387,8 @@ async fn item_reciever(
         }
     }
 
-    if flat_files.options.s3 {
-        if flat_files.options.parquet {
-            flat_files.create_arrow_cols().await?;
-        }
+    if flat_files.options.s3 && flat_files.options.parquet {
+        flat_files.create_arrow_cols().await?;
     }
 
     if count == 0 && flat_files.options.threads != 2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2770,7 +2770,7 @@ impl FlatFiles {
     }
 }
 
-fn value_convert(value: Value, describers: &mut Vec<Describer>, num: usize) -> String {
+fn value_convert(value: Value, describers: &mut [Describer], num: usize) -> String {
     let describer = &mut describers[num];
 
     match value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4051,7 +4051,7 @@ mod tests {
     #[test]
     fn string_list() {
         test_output(
-            &format!("fixtures/basic_list.json"),
+            "fixtures/basic_list.json",
             vec!["csv/main.csv", "csv/rating.csv", "csv/moo_names.csv"],
             json!({"arrays_new_table":true}),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3409,7 +3409,7 @@ async fn item_reciever(
 }
 
 #[cfg(not(target_family = "wasm"))]
-pub fn flatten(input: Box<dyn BufRead>, output: String, mut options: Options) -> Result<()> {
+pub fn flatten<R: BufRead + 'static>(input: R, output: String, mut options: Options) -> Result<()> {
     if options.threads == 0 {
         options.threads = num_cpus::get()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //!```
 //!
-//! Lower level usage, use the `FlatFiles` struct directly and supply options.  
+//! Lower level usage, use the `FlatFiles` struct directly and supply options.
 //!
 //!```
 //! use tempfile::TempDir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1611,17 +1611,15 @@ impl FlatFiles {
     }
 
     pub fn use_tables_csv(&mut self) -> Result<()> {
-        let reader: Box<dyn Read>;
-
-        if self.options.tables_csv_string.is_empty() {
-            reader = Box::new(File::open(&self.options.tables_csv).context(
-                FlattererReadSnafu {
+        let reader: Box<dyn Read> = if self.options.tables_csv_string.is_empty() {
+            Box::new(
+                File::open(&self.options.tables_csv).context(FlattererReadSnafu {
                     filepath: PathBuf::from(&self.options.tables_csv),
-                },
-            )?);
+                })?,
+            )
         } else {
-            reader = Box::new(self.options.tables_csv_string.as_bytes());
-        }
+            Box::new(self.options.tables_csv_string.as_bytes())
+        };
 
         let mut tables_reader = Reader::from_reader(reader);
 
@@ -1635,17 +1633,15 @@ impl FlatFiles {
     }
 
     pub fn use_fields_csv(&mut self) -> Result<()> {
-        let reader: Box<dyn Read>;
-
-        if self.options.fields_csv_string.is_empty() {
-            reader = Box::new(File::open(&self.options.fields_csv).context(
-                FlattererReadSnafu {
+        let reader: Box<dyn Read> = if self.options.fields_csv_string.is_empty() {
+            Box::new(
+                File::open(&self.options.fields_csv).context(FlattererReadSnafu {
                     filepath: PathBuf::from(&self.options.fields_csv),
-                },
-            )?);
+                })?,
+            )
         } else {
-            reader = Box::new(self.options.fields_csv_string.as_bytes());
-        }
+            Box::new(self.options.fields_csv_string.as_bytes())
+        };
 
         let mut fields_reader = Reader::from_reader(reader);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3140,12 +3140,10 @@ pub fn flatten_all(inputs: Vec<String>, output: String, options: Options) -> Res
     for input in inputs {
         let flat_files_result = flatten_single(input, flat_files);
 
-        if flat_files_result.is_err() {
-            if !s3 {
-                remove_dir_all(PathBuf::from(&output)).context(FlattererRemoveDirSnafu {
-                    filename: PathBuf::from(&output).to_string_lossy(),
-                })?;
-            }
+        if flat_files_result.is_err() && !s3 {
+            remove_dir_all(PathBuf::from(&output)).context(FlattererRemoveDirSnafu {
+                filename: PathBuf::from(&output).to_string_lossy(),
+            })?;
         }
         flat_files = flat_files_result?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1920,7 +1920,7 @@ impl FlatFiles {
         } else {
             let tmp_path = self.output_dir.join("tmp");
 
-            if remove_dir_all(&tmp_path).is_err() {
+            if remove_dir_all(tmp_path).is_err() {
                 log::warn!("Temp files can not be deleted, continuing anyway");
             }
             self.log_info("Writing metadata files");
@@ -2675,7 +2675,7 @@ impl FlatFiles {
                 fields.push(format!(
                     "    \"{}\" {}",
                     metadata.field_titles_lc[order],
-                    postgresql::to_postgresql_type(&metadata.describers[order].guess_type().0)
+                    postgresql::to_postgresql_type(metadata.describers[order].guess_type().0)
                 ));
             }
             write!(postgresql_schema, "{}", fields.join(",\n")).context(
@@ -2745,7 +2745,7 @@ impl FlatFiles {
                 fields.push(format!(
                     "    \"{}\" {}",
                     metadata.field_titles_lc[order],
-                    postgresql::to_postgresql_type(&metadata.describers[order].guess_type().0)
+                    postgresql::to_postgresql_type(metadata.describers[order].guess_type().0)
                 ));
             }
             write!(sqlite_schema, "{}", fields.join(",\n")).context(FlattererFileWriteSnafu {
@@ -3120,7 +3120,7 @@ pub fn flatten_all(inputs: Vec<String>, output: String, options: Options) -> Res
             .files_memory
             .get("fields.csv")
             .expect("should exist");
-        final_options.fields_csv_string = String::from_utf8_lossy(&fields_bytes).to_string();
+        final_options.fields_csv_string = String::from_utf8_lossy(fields_bytes).to_string();
         final_options.only_fields = true;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4007,7 +4007,7 @@ mod tests {
                 assert!(
                     error.to_string().contains(error_text),
                     "error was {}",
-                    error.to_string()
+                    error
                 )
             } else {
                 panic!(
@@ -4031,7 +4031,7 @@ mod tests {
             if test_file.ends_with(".json") {
                 let value: Value = serde_json::from_reader(
                     File::open(format!("{}/{}", output_path.clone(), test_file))
-                        .expect(&format!("{test_file} should exist")),
+                        .unwrap_or_else(|_| panic!("{test_file} should exist")),
                 )
                 .unwrap();
                 insta::assert_yaml_snapshot!(new_name, &value, {

--- a/src/yajlparser.rs
+++ b/src/yajlparser.rs
@@ -1,6 +1,7 @@
+use std::io::prelude::*;
+
 use crossbeam_channel::Sender;
 use smartstring::alias::String as SmartString;
-use std::io::prelude::*;
 use yajlish::{Context, Enclosing, Handler, Status};
 
 use crate::FlatFiles;
@@ -111,7 +112,8 @@ impl<W: std::io::Write> ParseJson<W> {
             if !value.is_object() {
                 self.error = format!(
                     "Value at array position {} is not an object: value is `{}`",
-                    self.count - 1, value
+                    self.count - 1,
+                    value
                 );
                 return Status::Abort;
             }
@@ -303,11 +305,13 @@ impl<W: std::io::Write> Handler for ParseJson<W> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::fs::File;
+
     use crossbeam_channel::bounded;
     use serde_json::Value;
-    use std::fs::File;
     use yajlish::Parser;
+
+    use super::*;
 
     fn parse(file: &str, stream: bool) -> (Vec<Value>, Vec<Vec<SmartString>>, String) {
         let mut outer: Vec<u8> = vec![];

--- a/src/yajlparser.rs
+++ b/src/yajlparser.rs
@@ -136,7 +136,7 @@ impl<W: std::io::Write> ParseJson<W> {
             };
             return Status::Continue;
         }
-        return Status::Continue;
+        Status::Continue
     }
 
     fn send_json(&mut self, _ctx: &Context) -> Status {


### PR DESCRIPTION
General code improvements, mostly clippy lints

- Formatting, trailing whitespaces
- Suppressed large enum variants lints
- Suppressed invalid regex lint error properly
- Removed unnecessary late init uses
- `flatten` now accepts the reader as a generic type instead of a boxed trait object
- Removed unnecessary references where they would be immediately dereferenced
- Changed `&mut Vec<T>` to `&mut [T]` because the vec-exclusive methods were not used
- Replaced use of deprecated `IndexMap::remove` with `IndexMap::swap_remove`, behavior remained identical
- Removed unnecessary conversions
- Optimized usage of `Result::expect` with formatted string
- Flattened nested `if` blocks
- Removed unnecessary uses of `format!` and allocated strings
- General code style improvements